### PR TITLE
Update FileSystemEntry and FujiFilePicker

### DIFF
--- a/MountFujiApp/Extensions/StratergiesWireUp.cs
+++ b/MountFujiApp/Extensions/StratergiesWireUp.cs
@@ -28,7 +28,12 @@ public static class StratergiesWireUp
     /// <param name="services"></param>
     public static void AddStrategies(this IServiceCollection services)
     {
-
+        // I don't like this approach and prefer adding the strategy to the platform specific 
+        // projects, BUT, when unit testing we use net8 as a platform and that doesn't have
+        // a platform folder in the project and so its build fails.
+        //
+        // But once nasty #if here is better than smearing it all over the code
+        
 #if MACCATALYST
         AddMacStrategies(services);
 #elif WINDOWS
@@ -42,11 +47,13 @@ public static class StratergiesWireUp
     private static void AddMacStrategies(IServiceCollection services)
     {
         services.AddTransient<IAppSelectorStrategy, MacOsAppSelectorStrategy>();
+        services.AddTransient<IDriveRetrievalStrategy, MacOsDriveRetrievalStrategy>();
     }
 
     private static void AddWindowsStrategies(IServiceCollection services)
     {
         services.AddTransient<IAppSelectorStrategy, WindowsAppSelectorStrategy>();
+        services.AddTransient<IDriveRetrievalStrategy, WindowsDriveRetrievalStrategy>();
     }
 
 

--- a/MountFujiApp/Models/FileSystemEntry.cs
+++ b/MountFujiApp/Models/FileSystemEntry.cs
@@ -25,20 +25,15 @@ public enum EntryType
 
     ParentNavigation,
     Folder,
-    File
-    
+    File,
+    Null
 }
 
-public class FileSystemEntry
+public class FileSystemEntry(string path, EntryType entryType)
 {
-    public string Path { get; set; }
-    public EntryType EntryType { get; private set; }
-    
-    public FileSystemEntry(string path, EntryType entryType)
-    {
-        this.Path = path;
-        this.EntryType = entryType;
-    }
+    public static FileSystemEntry Null = new FileSystemEntry("",EntryType.Null);
+    public string Path { get; set; } = path;
+    public EntryType EntryType { get; private set; } = entryType;
 
     public string DisplayName => (EntryType == EntryType.ParentNavigation) ? ".." : new DirectoryInfo(Path).Name;
 
@@ -47,4 +42,13 @@ public class FileSystemEntry
     public bool IsParentNavigation => EntryType == EntryType.ParentNavigation;
     
     public string Icon => (EntryType == EntryType.Folder || EntryType == EntryType.ParentNavigation) ? IconFont.Folder_open : IconFont.Description;
+}
+
+public class FileSystemDrive(string path, string displayName)
+{
+    public string Path { get; set; } = path;
+
+    public string DisplayName { get; set; } = displayName;
+
+    public string Icon => IconFont.Folder_special;
 }

--- a/MountFujiApp/MountFujiApp.csproj
+++ b/MountFujiApp/MountFujiApp.csproj
@@ -107,10 +107,6 @@
       </Compile>
     </ItemGroup>
 
-    <ItemGroup>
-      <Folder Include="Strategies\" />
-    </ItemGroup>
-
     <!-- Build Properties must be defined within these property groups to ensure successful publishing
        to the Mac App Store. See: https://aka.ms/maui-publish-app-store#define-build-properties-in-your-project-file -->
     <ItemGroup>

--- a/MountFujiApp/Services/Filesystem/FujiFilePickerService.cs
+++ b/MountFujiApp/Services/Filesystem/FujiFilePickerService.cs
@@ -65,7 +65,8 @@ public class FujiFilePickerService : IFujiFilePickerService
             if (complete is not null & popup.ViewModel.Confirmed && pickerType == PickerType.File)
             {
                 lastFolderAccessed = popup.ViewModel.CurrentFolder;
-                complete(popup.ViewModel.SelectedEntry.Path);
+                // TODO selected file i guess
+                complete(popup.ViewModel.SelectedFile.Path);
             }
             else  if (complete is not null & popup.ViewModel.Confirmed && pickerType == PickerType.Folder)
             {

--- a/MountFujiApp/Strategies/MacOSDrive.cs
+++ b/MountFujiApp/Strategies/MacOSDrive.cs
@@ -1,0 +1,90 @@
+// Mount Fuji - A front end for the Hatari Emulator
+//    Copyright (C) 2024  David Black
+// 
+//    This program is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+// 
+//    This program is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+// 
+//    You should have received a copy of the GNU General Public License
+//    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace MountFuji.Strategies;
+
+public interface IDriveRetrievalStrategy
+{
+    IEnumerable<FileSystemDrive> RetrieveDrives();
+}
+
+public class MacOsDriveRetrievalStrategy : IDriveRetrievalStrategy
+{
+    private const string SystemsFolder = "/System";
+    private const string VolumesFolder = "/Volumes";
+    private const string DocumentsFolder = "Documents";
+
+    public IEnumerable<FileSystemDrive> RetrieveDrives()
+    {
+        var res = new List<FileSystemDrive>();
+        var systemDrives = DriveInfo.GetDrives();
+        
+        
+        string homePath = Environment.GetEnvironmentVariable("HOME");
+        if (Path.Exists(homePath))
+        {
+            res.Add(new FileSystemDrive(homePath, "Home"));
+            var documentsPath = Path.Combine(homePath, DocumentsFolder);
+            if (Path.Exists(documentsPath))
+            {
+                res.Add(new FileSystemDrive(documentsPath, "Documents"));
+            }
+        }
+
+        foreach (var drive in systemDrives)
+        {
+            // exclude the RAM drive for things like /dev and the system volumes
+            if (drive.IsReady && drive.DriveType != DriveType.Ram && !drive.Name.StartsWith(SystemsFolder))
+            {
+                string displayName = drive.Name;
+                if (displayName.StartsWith(VolumesFolder))
+                {
+                    displayName = displayName.Replace($"{VolumesFolder}/", "");
+                }
+                else if (displayName == "/")
+                {
+                    displayName = "System";
+                }
+
+                res.Add(new FileSystemDrive(drive.Name, displayName));
+            }
+        }
+
+        return res;
+    }
+}
+
+public class WindowsDriveRetrievalStrategy : IDriveRetrievalStrategy
+{
+    public IEnumerable<FileSystemDrive> RetrieveDrives()
+    {
+        var res = new List<FileSystemDrive>();
+        
+        
+        string homePath = Environment.ExpandEnvironmentVariables("%HOMEDRIVE%%HOMEPATH%");
+        
+        var systemDrives = DriveInfo.GetDrives();
+        foreach (var drive in systemDrives)
+        {
+            if (drive.IsReady && !drive.Name.StartsWith("/"))
+            {
+                res.Add(new FileSystemDrive(drive.Name, drive.Name));
+            }
+        }
+
+        return res;
+    }
+}

--- a/MountFujiApp/Views/FujiFilePickerPopup.xaml
+++ b/MountFujiApp/Views/FujiFilePickerPopup.xaml
@@ -1,63 +1,113 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <mopups:PopupPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-                 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-                 xmlns:vm="clr-namespace:MountFuji.ViewModels"
-                 xmlns:mopups="clr-namespace:Mopups.Pages;assembly=Mopups"
-                 xmlns:models="clr-namespace:MountFuji.Models"
-                 x:Class="MountFuji.Views.FujiFilePickerPopup"
-                 x:DataType="vm:FujiFilePickerPopupViewModel"
+                  xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                  xmlns:vm="clr-namespace:MountFuji.ViewModels"
+                  xmlns:mopups="clr-namespace:Mopups.Pages;assembly=Mopups"
+                  xmlns:models="clr-namespace:MountFuji.Models"
+                  x:Class="MountFuji.Views.FujiFilePickerPopup"
+                  x:DataType="vm:FujiFilePickerPopupViewModel"
 
-                 Title="Fuji picker" BackgroundColor="#80000000"  CloseWhenBackgroundIsClicked="False" >
-    
-    
-    <Border WidthRequest="850" HeightRequest="635"  Style="{StaticResource DialogWindow}">
+                  Title="Fuji picker" BackgroundColor="#80000000" CloseWhenBackgroundIsClicked="False">
+
+
+    <Border WidthRequest="850" HeightRequest="635" Style="{StaticResource DialogWindow}">
         <Grid RowDefinitions="50,25,480,2,60" Margin="10">
-            <Label 
+            <Label
                 Grid.Row="0"
                 Grid.Column="0"
-    
+
                 Text="{Binding Title}"
                 VerticalOptions="Center"
                 HorizontalOptions="Center"
                 Style="{StaticResource H1Label}" />
-            
-                <HorizontalStackLayout Grid.Row="1">
-                    <Label Text="Folder: "></Label>
-                    <Label Text="{Binding CurrentFolder}"></Label>
-                </HorizontalStackLayout>
-            
-                <CollectionView
-                    SelectionMode="Single"
-                    SelectedItem="{Binding SelectedEntry}"
-                    ItemsSource="{Binding Entries}"
-                    
-                    Grid.Row="2"
-                    Grid.ColumnSpan="3"
-                    
-                    SelectionChangedCommand="{Binding SelectionChangedCommand}"
-                    >
-                  
+
+            <HorizontalStackLayout Grid.Row="1">
+                <Label Text="Folder: "></Label>
+                <Label Text="{Binding CurrentFolder}"></Label>
+            </HorizontalStackLayout>
+
+            <Grid Grid.ColumnSpan="3" Grid.Row="2" ColumnDefinitions="220,2,288,2,288">
+
+                <!-- Dividers -->
+                <Rectangle Style="{StaticResource DialogButtonsSeparator}" Grid.Column="1"></Rectangle>
+                <Rectangle Style="{StaticResource DialogButtonsSeparator}" Grid.Column="3"></Rectangle>
+                
+                
+                <!-- Drives list -->
+                <CollectionView Grid.Column="0"
+                                SelectionMode="Single"
+                                SelectedItem="{Binding SelectedDrive}"
+                                ItemsSource="{Binding Drives}"
+                                >
+
+                    <CollectionView.ItemTemplate>
+                        <DataTemplate x:DataType="models:FileSystemDrive">
+                            <HorizontalStackLayout Style="{StaticResource ContentViewItem}">
+                                <HorizontalStackLayout.GestureRecognizers>
+                                    <TapGestureRecognizer 
+                                        Command="{Binding Path=DriveTappedCommand, Source={RelativeSource AncestorType={x:Type vm:FujiFilePickerPopupViewModel}}}"
+                                        CommandParameter="{Binding .}" />
+                                </HorizontalStackLayout.GestureRecognizers>
+                                <Label Text="{Binding Icon}" Style="{StaticResource FujiPickerIcon}"
+                                       VerticalOptions="Center" />
+                                <Label Text="{Binding DisplayName}" FontSize="20" VerticalOptions="Center"
+                                       Margin="10,0,0,0" />
+                            </HorizontalStackLayout>
+                        </DataTemplate>
+                    </CollectionView.ItemTemplate>
+                </CollectionView>
+
+                <!-- Folder list -->
+                <CollectionView Grid.Column="2"
+                                SelectionMode="Single"
+                                SelectedItem="{Binding SelectedFolder}"
+                                ItemsSource="{Binding Folders}"
+                                SelectionChangedCommand="{Binding SelectedFolderChangedCommand}"
+                                >
+
                     <CollectionView.ItemTemplate>
                         <DataTemplate x:DataType="models:FileSystemEntry">
                             <HorizontalStackLayout Style="{StaticResource ContentViewItem}" >
-                                <Label  Text="{Binding Icon}" Style="{StaticResource FujiPickerIcon}" VerticalOptions="Center"/>
-                                <Label Text="{Binding DisplayName}" FontSize="20" VerticalOptions="Center" Margin="10,0,0,0"/>
+                                <Label Text="{Binding Icon}" Style="{StaticResource FujiPickerIcon}"
+                                       VerticalOptions="Center" />
+                                <Label Text="{Binding DisplayName}" FontSize="20" VerticalOptions="Center"
+                                       Margin="10,0,0,0" />
                             </HorizontalStackLayout>
                         </DataTemplate>
                     </CollectionView.ItemTemplate>
                 </CollectionView>
                 
-            <Rectangle Grid.Row="3"   Style="{StaticResource DialogButtonsSeparator}"></Rectangle>
+                <!-- File list -->
+                <CollectionView Grid.Column="4"
+                                SelectionMode="Single"
+                                SelectedItem="{Binding SelectedFile}"
+                                ItemsSource="{Binding Files}"
+                                SelectionChangedCommand="{Binding SelectedFileChangedCommand}">
 
-           
-            <HorizontalStackLayout Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="3" HorizontalOptions="End" >
+                    <CollectionView.ItemTemplate>
+                        <DataTemplate x:DataType="models:FileSystemEntry">
+                            <HorizontalStackLayout Style="{StaticResource ContentViewItem}">
+                                <Label Text="{Binding Icon}" Style="{StaticResource FujiPickerIcon}"
+                                       VerticalOptions="Center" />
+                                <Label Text="{Binding DisplayName}" FontSize="20" VerticalOptions="Center"
+                                       Margin="10,0,0,0" />
+                            </HorizontalStackLayout>
+                        </DataTemplate>
+                    </CollectionView.ItemTemplate>
+                </CollectionView>
+                
+                
+            </Grid>
+            <Rectangle Grid.Row="3" Style="{StaticResource DialogButtonsSeparator}"></Rectangle>
+
+
+            <HorizontalStackLayout Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="3" HorizontalOptions="End">
                 <Button VerticalOptions="Center" Text="Cancel" Command="{Binding CancelCommand}" Margin="0,0,15,0" />
                 <Button VerticalOptions="Center" Text="OK" Command="{Binding OkCommand}" Margin="0,0,0,0" />
             </HorizontalStackLayout>
         </Grid>
     </Border>
-    
-    
-    
+
+
 </mopups:PopupPage>


### PR DESCRIPTION
Refactored FileSystemEntry model, added FileSystemDrive model, and updated related methods in FujiFilePicker for improved file handling. The update provides a better navigation of files and folders in the app. Now, it is possible to fetch drives for MacOS and Windows differently, and display a list of folders and files separately. Also, added drive retrieval strategy patterns for MacOS and Windows.