### PR TITLE
Update App version and refactor unit tests

### DIFF
--- a/MountFujiApp/MountFujiApp.csproj
+++ b/MountFujiApp/MountFujiApp.csproj
@@ -31,7 +31,7 @@
         <ApplicationId>com.overtakenbyevents.mountfuji</ApplicationId>
 
         <!-- Versions -->
-        <ApplicationDisplayVersion>1.0.2</ApplicationDisplayVersion>
+        <ApplicationDisplayVersion>1.0.3</ApplicationDisplayVersion>
         <ApplicationVersion>2</ApplicationVersion>
 
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>


### PR DESCRIPTION
Updated the display version of the application in the csproj file ready for the next release.

Refactored the FujiFilePickerPopupViewModel unit tests by injecting Mock objects for IDriveRetrievalStrategy and IFileSystemService. This refactoring allows testing of different scenarios pertaining to selection changes and directory navigation.